### PR TITLE
fix gem version badge copy-pasta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gem Version](https://badge.fury.io/rb/parse_date.svg)](https://badge.fury.io/rb/preservation-client)
+[![Gem Version](https://badge.fury.io/rb/parse_date.svg)](https://badge.fury.io/rb/parse_date)
 [![Build Status](https://travis-ci.org/sul-dlss/parse_date.svg?branch=master)](https://travis-ci.org/sul-dlss/parse_date)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2d006b4ccb3100434f4a/maintainability)](https://codeclimate.com/github/sul-dlss/parse_date/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/2d006b4ccb3100434f4a/test_coverage)](https://codeclimate.com/github/sul-dlss/parse_date/test_coverage)


### PR DESCRIPTION
## Why was this change made?

b/c the badge on the README was erroneously pointing to preservation-client gem.

## Was the documentation (README, API, wiki, ...) updated?

n/a