### PR TITLE
return nil rather than raising exception when string is unparseable or is comprised of invalid years

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ ParseDate.parse_range('996–1021 CE')                    # (996..1021).to_a (di
 ParseDate.parse_range('1975 - 1905')                    # last year > first year, raises error
 ParseDate.parse_range('-100 - -150')                    # last year > first year, raises error
 ParseDate.parse_range('1975 or 1905')                   # last year > first year, raises error
-ParseDate.parse_range('2050')                           # year later than current year + 1, raises error
-ParseDate.parse_range('random text')                    # can't parse years, raises error
-ParseDate.parse_range(nil)                              # can't parse years, raises error
+ParseDate.parse_range('1975 - 2050')                    # single invalid year endpoint, raises error
+ParseDate.parse_range('2050')                           # nil - only invalid year endpoints present
+ParseDate.parse_range('2045 - 2050')                    # nil - only invalid year endpoints present
+ParseDate.parse_range('random text')                    # nil - can't parse years
+ParseDate.parse_range(nil)                              # nil - can't parse years
 
 ParseDate.earliest_year('12/25/00')                     # 2000
 ParseDate.earliest_year('5-1-21')                       # 1921

--- a/lib/parse_date.rb
+++ b/lib/parse_date.rb
@@ -42,6 +42,7 @@ class ParseDate
   def self.parse_range(date_str)
     first = earliest_year(date_str)
     last = latest_year(date_str)
+    return nil unless first || last
     raise ParseDate::Error, "Unable to parse range from '#{date_str}'" unless year_range_valid?(first, last)
 
     range_array(first, last)

--- a/spec/parse_date_spec.rb
+++ b/spec/parse_date_spec.rb
@@ -59,10 +59,21 @@ RSpec.describe ParseDate do
 
       context 'when year is invalid' do
         [
+          '2050', # all endpoints later than current year + 1
+          '2045 - 2050', # all endpoints later than current year + 1
+        ].each do |example|
+          it "'#{example}' returns nil" do
+            expect(ParseDate.parse_range(example)).to be nil
+          end
+        end
+      end
+
+      context 'when range is invalid' do
+        [
           '1975 or 1905', # last year > first year
           '-100 - -150', # last year > first year
           '1975 - 1905', # last year > first year
-          '2050', # year later than current year + 1
+          '1975 - 2050', # one invalid year endpoint
         ].each do |example|
           it "raises error: '#{example}'" do
             exp_msg_regex = /Unable to parse range from '#{example}'/
@@ -71,14 +82,16 @@ RSpec.describe ParseDate do
         end
       end
     end
+
     context 'when years cannot be parsed' do
       [
         'random text',
+        '[n.d.]',
         nil,
+        '2045 - 2050', # only invalid year endpoints
       ].each do |example|
-        it "raises error: '#{example}'" do
-          exp_msg_regex = /Unable to parse range from '#{example}'/
-          expect { ParseDate.parse_range(example) }.to raise_error(ParseDate::Error, exp_msg_regex)
+        it "'#{example}' returns nil" do
+          expect(ParseDate.parse_range(example)).to be nil
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

DLME Sakip has date string `[n.d.]`.  We want `parse_range` to quietly return `nil`, not throw an exception, for cases like this. 

Note that this change as coded _also_ means that:
- a date string comprised only of invalid year(s) such as `2050` will also silently return `nil` from `parse_range`.

So the ParseDate::Error is thrown from `parse_range` only when:
- both years are valid but the last year > first year. (e.g. `1975 - 1905` )
- one of the endpoint years is invalid (e.g. `1975 - 2050`)

## Was the documentation (README, API, wiki, ...) updated?

yes, README examples