### PR TITLE
Remove per-project config (use global config for org)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,0 @@
-comment: false
-coverage:
-  status:
-    project: true


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



